### PR TITLE
fix: use guest role for sessions without a user assigned

### DIFF
--- a/apps/frontend/app/[locale]/(unauthenticated)/page.tsx
+++ b/apps/frontend/app/[locale]/(unauthenticated)/page.tsx
@@ -1,3 +1,5 @@
+// noinspection RequiredAttributes This is only for Webstorm, since the types seem to be too advanced for it
+
 import { CanUserServer } from '@/features/auth/components/CanUser.server'
 import { AddTestButton, RemoveTestButton, TestItemList } from '@/features/test'
 import { LoggingWysiwygEditor } from '@/features/test/components/LoggingWysiwygEditor'

--- a/apps/frontend/features/auth/auth.hooks.tsx
+++ b/apps/frontend/features/auth/auth.hooks.tsx
@@ -8,7 +8,9 @@ export function useSessionPermission<
 >(
   target: Obj,
   action: Action,
-  ...data: ConditionalMethodParam<Permissions[Obj][Action]>
+  ...data: Permissions[Obj][Action] extends never
+    ? []
+    : [Permissions[Obj][Action]]
 ) {
   const { data: session } = useSession()
   const user = session?.user
@@ -17,5 +19,3 @@ export function useSessionPermission<
     [user, target, action, data],
   )
 }
-
-type ConditionalMethodParam<Value> = Value extends never ? [] : [Value]

--- a/apps/frontend/features/auth/auth.hooks.tsx
+++ b/apps/frontend/features/auth/auth.hooks.tsx
@@ -1,0 +1,21 @@
+import { type Permissions, hasPermission } from '@repo/authorization'
+import { useSession } from 'next-auth/react'
+import { useMemo } from 'react'
+
+export function useSessionPermission<
+  Obj extends keyof Permissions,
+  Action extends keyof Permissions[Obj],
+>(
+  target: Obj,
+  action: Action,
+  ...data: ConditionalMethodParam<Permissions[Obj][Action]>
+) {
+  const { data: session } = useSession()
+  const user = session?.user
+  return useMemo(
+    () => hasPermission(user, target, action, ...data),
+    [user, target, action, data],
+  )
+}
+
+type ConditionalMethodParam<Value> = Value extends never ? [] : [Value]

--- a/apps/frontend/features/auth/auth.utils.ts
+++ b/apps/frontend/features/auth/auth.utils.ts
@@ -1,12 +1,10 @@
 import { authMiddleware } from '@/auth'
 import { type Permissions, hasPermission } from '@repo/authorization'
-import type { UserSelect } from '@repo/database/schema'
 
 export async function hasSessionPermission<
   Obj extends keyof Permissions,
   Action extends keyof Permissions[Obj],
 >(target: Obj, action: Action, data = undefined as Permissions[Obj][Action]) {
   const session = await authMiddleware()
-  if (!session?.user) return false
-  return hasPermission(session.user as UserSelect, target, action, data)
+  return hasPermission(session?.user, target, action, data)
 }

--- a/apps/frontend/features/auth/auth.utils.ts
+++ b/apps/frontend/features/auth/auth.utils.ts
@@ -4,7 +4,13 @@ import { type Permissions, hasPermission } from '@repo/authorization'
 export async function hasSessionPermission<
   Obj extends keyof Permissions,
   Action extends keyof Permissions[Obj],
->(target: Obj, action: Action, data = undefined as Permissions[Obj][Action]) {
+>(
+  target: Obj,
+  action: Action,
+  ...data: Permissions[Obj][Action] extends never
+    ? []
+    : [Permissions[Obj][Action]]
+) {
   const session = await authMiddleware()
-  return hasPermission(session?.user, target, action, data)
+  return hasPermission(session?.user, target, action, ...data)
 }

--- a/apps/frontend/features/auth/components/CanUser.client.tsx
+++ b/apps/frontend/features/auth/components/CanUser.client.tsx
@@ -1,6 +1,5 @@
 'use client'
 import { type Permissions, hasPermission } from '@repo/authorization'
-import type { UserSelect } from '@repo/database/schema'
 import { useSession } from 'next-auth/react'
 import type { PropsWithChildren, ReactNode } from 'react'
 
@@ -25,8 +24,6 @@ export function CanUserClient<
   fallback,
 }: PropsWithChildren<CanUserProps<Obj, Action>>): ReactNode {
   const { data: session } = useSession()
-  if (!session?.user) return fallback
-  if (!hasPermission(session.user as UserSelect, target, action, data))
-    return fallback
+  if (!hasPermission(session?.user, target, action, data)) return fallback
   return children
 }

--- a/apps/frontend/features/auth/components/CanUser.client.tsx
+++ b/apps/frontend/features/auth/components/CanUser.client.tsx
@@ -9,9 +9,10 @@ type CanUserProps<
 > = {
   target: Obj
   action: Action
-  data?: Permissions[Obj][Action]
   fallback?: ReactNode
-}
+} & (Permissions[Obj][Action] extends never
+  ? { data?: undefined }
+  : { data: Permissions[Obj][Action] })
 
 export function CanUserClient<
   Obj extends keyof Permissions,
@@ -19,11 +20,13 @@ export function CanUserClient<
 >({
   target,
   action,
-  data = undefined as Permissions[Obj][Action],
+  data,
   children,
   fallback,
 }: PropsWithChildren<CanUserProps<Obj, Action>>): ReactNode {
   const { data: session } = useSession()
-  if (!hasPermission(session?.user, target, action, data)) return fallback
+  // biome-ignore lint/suspicious/noExplicitAny: This is the correct type, TypeScript just doesn't know
+  if (!hasPermission(session?.user, target, action, ...([data] as any)))
+    return fallback
   return children
 }

--- a/apps/frontend/features/auth/components/CanUser.server.tsx
+++ b/apps/frontend/features/auth/components/CanUser.server.tsx
@@ -1,7 +1,6 @@
 import 'server-only'
 import { authMiddleware } from '@/auth'
 import { type Permissions, hasPermission } from '@repo/authorization'
-import type { UserSelect } from '@repo/database/schema'
 import type { PropsWithChildren, ReactNode } from 'react'
 
 type CanUserProps<
@@ -26,8 +25,6 @@ export async function CanUserServer<
   // @ts-expect-error This technically has to return a promise, but TypeScript cannot handle async react components yet
 }: PropsWithChildren<CanUserProps<Obj, Action>>): ReactNode {
   const session = await authMiddleware()
-  if (!session?.user) return null
-  if (!hasPermission(session.user as UserSelect, target, action, data))
-    return fallback
+  if (!hasPermission(session?.user, target, action, data)) return fallback
   return children
 }

--- a/apps/frontend/features/test/components/AddAdminRoleButton.tsx
+++ b/apps/frontend/features/test/components/AddAdminRoleButton.tsx
@@ -1,4 +1,7 @@
+// noinspection RequiredAttributes This is only for Webstorm, since the types seem to be too advanced for it
+
 'use client'
+
 import { CanUserClient } from '@/features/auth/components/CanUser.client'
 import { useRouter } from '@/features/i18n/routing'
 import { toggleAdminRole } from '@/features/test/test.actions'

--- a/packages/authorization/index.ts
+++ b/packages/authorization/index.ts
@@ -3,7 +3,7 @@ import type { UserSelect } from '@repo/database/schema'
 
 type PermissionCheck<Data> =
   | boolean
-  | ((user: UserSelect, data: Data) => boolean)
+  | ((user: UserSelect | undefined, data: Data) => boolean)
 
 type RolesWithPermissions = {
   [Role in RolesType]: Partial<{
@@ -56,12 +56,13 @@ export function hasPermission<
   Obj extends keyof Permissions,
   Action extends keyof Permissions[Obj],
 >(
-  user: UserSelect,
+  user: UserSelect | undefined,
   obj: Obj,
   action: Action,
   data = undefined as Permissions[Obj][Action],
 ) {
-  return user.roles.some((role: RolesType) => {
+  const roles = user?.roles ?? (['guest'] as const)
+  return roles.some((role: RolesType) => {
     const permission = (PERMISSIONS as RolesWithPermissions)[role][obj]?.[
       action
     ] as PermissionCheck<Permissions[Obj][Action]>

--- a/packages/authorization/index.ts
+++ b/packages/authorization/index.ts
@@ -59,7 +59,7 @@ export function hasPermission<
   user: UserSelect | undefined,
   obj: Obj,
   action: Action,
-  data = undefined as Permissions[Obj][Action],
+  ...data: ConditionalMethodParam<Permissions[Obj][Action]>
 ) {
   const roles = user?.roles ?? (['guest'] as const)
   return roles.some((role: RolesType) => {
@@ -68,6 +68,11 @@ export function hasPermission<
     ] as PermissionCheck<Permissions[Obj][Action]>
     if (permission === undefined) return false
     if (typeof permission === 'boolean') return permission
-    return data !== undefined && permission(user, data)
+    return (
+      data !== undefined &&
+      permission(user, data?.[0] as Permissions[Obj][Action])
+    )
   })
 }
+
+type ConditionalMethodParam<Value> = Value extends never ? [] : [Value]


### PR DESCRIPTION
Previously "guest" sessions where not allowed to do anything, now they use the permissions defined through the "guest" role